### PR TITLE
Introduce AI generate tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,7 @@ It's a dynamic website but light as a feather compared to building on top of a C
 - Postgres 14+
 - MinIO or other S3-compatible storage solution
 
-You can boot a container with MinIO locally using this docker image:
-```bash
-docker run \
-   -p 9000:9000 \
-   -p 9090:9090 \
-   --name minio \
-   -v ~/minio/data:/data \
-   -e "MINIO_ROOT_USER=ROOTNAME" \
-   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
-   quay.io/minio/minio server /data --console-address ":9090"
-```
+
 
 These are needed to run the example as is, but you can choose any other database and file storage solution.
 
@@ -37,6 +27,18 @@ git clone https://github.com/your-user/your-website.git
 cd your-website
 ```
 
+For media storage this template is configured to use S3 compatible storage. For local development you can run a container with MinIO using this docker image:
+```bash
+docker run \
+   -p 9000:9000 \
+   -p 9090:9090 \
+   --name minio \
+   -v ~/minio/data:/data \
+   -e "MINIO_ROOT_USER=ROOTNAME" \
+   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
+   quay.io/minio/minio server /data --console-address ":9090"
+```
+
 Create a `.env` file and set the following environment variables to point to your development database and MinIO instance:
 
 ```bash
@@ -47,7 +49,16 @@ VITE_S3_ENDPOINT=https://minio.ew-dev-assets--000000000000.addon.code.run
 VITE_S3_BUCKET=editable-website
 VITE_ASSET_PATH=https://minio.ew-dev-assets--000000000000.addon.code.run/editable-website
 VITE_ADMIN_PASSWORD=00000000000000000000000000000000000000
+VITE_OPENAI_API_KEY=00000000000000000000000000000000000000
 ```
+
+If you are running MinIO locally, you can use these default environment credentials to connect to it: 
+```bash
+VITE_S3_ENDPOINT=http://127.0.0.1:9000
+VITE_S3_BUCKET=editable-website
+VITE_ASSET_PATH=http://127.0.0.1:9000/editable-website
+```
+
 
 Seed the database:
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ It's a dynamic website but light as a feather compared to building on top of a C
 - Postgres 14+
 - MinIO or other S3-compatible storage solution
 
+You can boot a container with MinIO locally using this docker image:
+```bash
+docker run \
+   -p 9000:9000 \
+   -p 9090:9090 \
+   --name minio \
+   -v ~/minio/data:/data \
+   -e "MINIO_ROOT_USER=ROOTNAME" \
+   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
+   quay.io/minio/minio server /data --console-address ":9090"
+```
+
 These are needed to run the example as is, but you can choose any other database and file storage solution.
 
 ## Step 1 - Development setup

--- a/src/lib/components/tools/ToggleAICompletion.svelte
+++ b/src/lib/components/tools/ToggleAICompletion.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { classNames } from '$lib/util';
+  import { anythingSelected } from '$lib/prosemirrorCommands.js';
+
+  export let editorView;
+  export let editorState;
+  export let isPromptOpen;
+  $: disabled = !anythingSelected(editorState);
+
+  $: schema = editorState.schema;
+
+  function handleClick() {
+    isPromptOpen = !isPromptOpen;
+    editorView.focus();
+  }
+</script>
+
+<button
+  on:click={handleClick}
+  {disabled}
+  class={classNames(
+    isPromptOpen ? 'bg-gray-900 text-white' : 'hover:bg-gray-100',
+    'sm:mx-1 rounded-full p-2 disabled:opacity-30'
+  )}
+>
+  <slot />
+</button>

--- a/src/lib/prosemirrorCommands.js
+++ b/src/lib/prosemirrorCommands.js
@@ -18,3 +18,7 @@ export function insertImage(state /*, dispatch, editorView, src*/) {
   if (!canInsert(state, nodeType)) return false;
   return true;
 }
+
+export function anythingSelected(state) {
+  return !state.selection.empty;
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -165,3 +165,26 @@ export async function fetchJSON(method, url, data = undefined) {
   const result = await response.json();
   return result;
 }
+
+export async function askGPT(prompt, existingText) {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'system',
+          content: `You are a helpful assistant helping out writing copy for a website. User has selected the following text ${existingText} in a CMS editor. Please write a short paragraph that will replace the text based on the following prompt`
+        },
+        { role: 'user', content: prompt }
+      ]
+    }),
+    headers: {
+      'content-type': 'application/json',
+      Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`
+    }
+  });
+  if (!response.ok) throw new Error(response.statusText);
+  const result = await response.json();
+  return result.choices[0].message.content;
+}

--- a/src/routes/api/generate/+server.js
+++ b/src/routes/api/generate/+server.js
@@ -1,0 +1,10 @@
+import { json } from '@sveltejs/kit';
+import { askGPT } from '$lib/util.js';
+
+export async function POST({ request, locals }) {
+  const user = locals.user;
+  if (!user) throw new Error('Not authorized');
+  const { prompt, existingText } = await request.json();
+  const completion = await askGPT(prompt, existingText);
+  return json(completion);
+}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <svelte:head>
-  <title>Anmelden</title>
+  <title>Login</title>
 </svelte:head>
 
 <Limiter>


### PR DESCRIPTION
This PR adds a little button that can help re-iterate or generate copy for text fields using ChatGPT.

Since it is using the context of the selected text, it is disabled if no text is selected:
<img width="1183" alt="image" src="https://user-images.githubusercontent.com/495782/230974235-2f54f5ba-13c2-49de-9852-54b77f157fbe.png">

When opened a modal appears where user can ask for a completion or generate something creative:
<img width="1163" alt="image" src="https://user-images.githubusercontent.com/495782/230974479-05746a93-cd22-43ac-8e7f-9820d8a9cd6c.png">

It then replaces the selected text with result from OpenAI chat /completions API ✨
<img width="994" alt="image" src="https://user-images.githubusercontent.com/495782/230975890-c642ce36-b7ec-4209-813f-921b482dd956.png">

You will need to provide your OpenAI key in `.env`. This is mostly just to showcase some of the possibilities with this template and is not a must have feature. Quite cool though 😎