### PR TITLE
Don't include the current article in the list of next articles

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -109,7 +109,7 @@ export async function getNextArticle(slug) {
       )
       UNION
       (
-        SELECT title, teaser, slug, published_at FROM articles ORDER BY published_at DESC LIMIT 1
+        SELECT title, teaser, slug, published_at FROM articles WHERE slug <> $1 ORDER BY published_at DESC LIMIT 1
       )
       ORDER BY published_at ASC
       LIMIT 1;

--- a/src/routes/blog/[slug]/+page.server.js
+++ b/src/routes/blog/[slug]/+page.server.js
@@ -3,7 +3,8 @@ import { getArticleBySlug, getNextArticle } from '$lib/api';
 export async function load({ params, locals }) {
   const currentUser = locals.user;
   const data = await getArticleBySlug(params.slug);
-  const articles = [await getNextArticle(params.slug)];
+  const nextArticle = await getNextArticle(params.slug);
+  const articles = nextArticle ? [nextArticle] : [];
   return {
     ...data,
     currentUser,


### PR DESCRIPTION
With only one article, the current article is listed as the next article. This PR fixes that behavior.