### PR TITLE
Introduce Docker compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.idea

--- a/README.md
+++ b/README.md
@@ -29,20 +29,35 @@ git clone https://github.com/your-user/your-website.git
 cd your-website
 ```
 
-Create a `.env` file and set the following environment variables to point to your development database and MinIO instance:
-
+### Docker setup, Postgres and Minio with docker compose
+For a docker setup that boots up postgres and minio in containers, simply run:
 ```bash
-DB_URL=postgresql://$USER@localhost:5432/editable-website
-S3_ACCESS_KEY=000000000000000000
-S3_SECRET_ACCESS_KEY=00000000000000000000000000000000000000
-S3_ENDPOINT=https://minio.ew-dev-assets--000000000000.addon.code.run
-S3_BUCKET=editable-website
-ADMIN_PASSWORD=00000000000000000000000000000000000000
-PUBLIC_ASSET_PATH=https://minio.ew-dev-assets--000000000000.addon.code.run/editable-website
+docker compose up
+```
+
+For Minio you would also need to login locally to http://127.0.0.1:9001/ with the credentials in the docker compose file: `EDITABLEUSER/EDITABLEPASSWORD`.
+- Create access keys and put these credentials in your .env. as `S3_ACCESS_KEY` and `S3_SECRET_ACCESS_KEY`.
+- Create a bucket called `editable-website`. Set it to be accessible to the public.
+- Create `.env` file and make sure the following environment variables are defined:
+```bash
+DB_URL=postgresql://postgres:postgres@localhost:5434/editable-website
+ADMIN_PASSWORD=<your-admin-password-to-website>
+S3_ACCESS_KEY=<your-minio-access-key>
+S3_SECRET_ACCESS_KEY=<your-minio-secret-access-key>
+S3_ENDPOINT=http://127.0.0.1:9000
+S3_BUCKET=<bucket-name(editable-website)>
+PUBLIC_ASSET_PATH=http://127.0.0.1:9000/editable-website
 ```
 
 Seed the database:
 
+```bash
+psql postgresql://postgres:postgres@localhost:5434/editable-website -a -f sql/schema.sql
+```
+
+### Local setup, Postgres and Minio
+If you want to connect to a local database you can set the `DB_URL` to `postgresql://$USER@localhost:5432/editable-website`
+With that database url you can seed the database with:
 ```bash
 psql -h localhost -U $USER -d editable-website -a -f sql/schema.sql
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:14.1-alpine
+    restart: always
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=editable-website
+    ports:
+      - '5434:5432'
+    volumes:
+      - db:/var/lib/postgresql/data
+  minio:
+    image: quay.io/minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=EDITABLEUSER
+      - MINIO_ROOT_PASSWORD=EDITABLEPASSWORD
+    volumes:
+      - minio_volume:/data
+    ports:
+      - 9000:9000
+      - 9001:9001
+
+volumes:
+  db:
+    driver: local
+  minio_volume:
+    driver: local

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -2,51 +2,6 @@ export function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
 }
 
-/*!
-Math.uuid.js (v1.4)
-http://www.broofa.com
-mailto:robert@broofa.com
-Copyright (c) 2010 Robert Kieffer
-Dual licensed under the MIT and GPL licenses.
-*/
-
-/**
- * Generates a unique id.
- *
- * @param {String} [prefix] if provided the UUID will be prefixed.
- * @param {Number} [len] if provided a UUID with given length will be created.
- * @return A generated uuid.
- */
-export function uuid(prefix, len) {
-  if (prefix && prefix[prefix.length - 1] !== '-') {
-    prefix = prefix.concat('-');
-  }
-  const chars = '0123456789abcdefghijklmnopqrstuvwxyz'.split('');
-  const uuid = [];
-  const radix = 16;
-  let idx;
-  len = len || 32;
-  if (len) {
-    // Compact form
-    for (idx = 0; idx < len; idx++) uuid[idx] = chars[0 | (Math.random() * radix)];
-  } else {
-    // rfc4122, version 4 form
-    let r;
-    // rfc4122 requires these characters
-    uuid[8] = uuid[13] = uuid[18] = uuid[23] = '-';
-    uuid[14] = '4';
-    // Fill in random data.  At i==19 set the high bits of clock sequence as
-    // per rfc4122, sec. 4.1.5
-    for (idx = 0; idx < 36; idx++) {
-      if (!uuid[idx]) {
-        r = 0 | (Math.random() * 16);
-        uuid[idx] = chars[idx === 19 ? (r & 0x3) | 0x8 : r];
-      }
-    }
-  }
-  return (prefix || '') + uuid.join('');
-}
-
 export function formatDate(dateString, withTime) {
   const date = new Date(dateString);
   if (withTime) {
@@ -60,7 +15,7 @@ export function formatDate(dateString, withTime) {
         hour: 'numeric',
         minute: 'numeric',
         hour12: true
-      }
+      };
       if (date.getFullYear() !== new Date().getFullYear()) {
         opts.year = 'numeric';
       }


### PR DESCRIPTION
This PR introduces a way to boot up database and storage locally in docker containers to make it very easy to get going with editable website development. 

```bash
docker compose up
```
The setup is documented and reflected in `README` as well. I also included some additional useful information regarding `minio` that I remembered I struggled with first time I set this up. 

- docker compose and documentation
- uuid duplicated dead code in `util` removed